### PR TITLE
Aborts Deploy if not on Master

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "if [[ $(git rev-parse --abbrev-ref HEAD) != \"master\" ]]; then echo \"\\033[0;31mERROR: \\033[0mYou be on the master branch to deploy.\nPlease checkout and pull the latest version of master before deploying.\"; exit 0; fi; npm run build && gh-pages -d build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
This adds a check into our npm deploy script to make sure we only deploy the master branch.

If you `npm run deploy` on a branch other than master, you will get the following error:
> ERROR: You be on the master branch to deploy.
> Please checkout and pull the latest version of master before deploying.
