### PR TITLE
New and improved deploy script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1818,9 +1818,9 @@
       "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -3319,15 +3319,15 @@
       }
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+      "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001208",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.712",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "bser": {
@@ -3506,9 +3506,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA=="
+      "version": "1.0.30001211",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz",
+      "integrity": "sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -4394,9 +4394,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4882,9 +4882,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.712",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
-      "integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw=="
+      "version": "1.3.717",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
+      "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -6025,17 +6025,12 @@
         "schema-utils": "^2.5.0"
       }
     },
-<<<<<<< HEAD
-<<<<<<< Updated upstream
-=======
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
     },
-=======
->>>>>>> f34e997f4dbb4c30a916f500cc77bd4414612d93
     "filename-reserved-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
@@ -6063,10 +6058,6 @@
         "humanize-url": "^1.0.0"
       }
     },
-<<<<<<< HEAD
->>>>>>> Stashed changes
-=======
->>>>>>> f34e997f4dbb4c30a916f500cc77bd4414612d93
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -6660,9 +6651,9 @@
       }
     },
     "harmony-reflect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
-      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="
     },
     "has": {
       "version": "1.0.3",
@@ -9713,9 +9704,9 @@
       "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -10584,11 +10575,10 @@
       }
     },
     "postcss-initial": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.2.tgz",
-      "integrity": "sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.4.tgz",
+      "integrity": "sha512-3RLn6DIpMsK1l5UUy9jxQvoDeUN4gP939tDcKUHD/kM8SGSKbFAnvkpFpj3Bhtz3HGk1jWY5ZNWX6mPta5M9fg==",
       "requires": {
-        "lodash.template": "^4.5.0",
         "postcss": "^7.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "deploy": "if [[ $(git rev-parse --abbrev-ref HEAD) != \"master\" ]]; then echo \"\\033[0;31mERROR: \\033[0mYou must be on the master branch to deploy.\nPlease checkout and pull the latest version of master before deploying.\"; exit 0; fi; npm run build && gh-pages -d build",
+    "deploy": "node scripts/deploy.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,51 @@
+const { ghpages } = require('gh-pages');
+const { exit } = require('process')
+const execSync = require('child_process').execSync;
+
+// Intended Branch to deploy
+const deployBranch = 'master'
+
+// Style codes for formatting
+const format = {
+    bold: "\x1b[1m",
+    red: "\x1b[31m",
+    reset: "\x1b[0m"
+}
+
+
+// DEPLOY SCRIPT
+// This functions deploys the current code to production
+//  1. Checks that you are on the intended deploy branch
+//  2. Creates a production build: `npm run build`
+//  3. Deploys to production: `gh-pages -d build` 
+const deploy = () => {
+    console.log(`${format.bold}Beginning The Deploy Process!\n${format.reset}`);
+
+    // Assert that the current branch is the deploy branch
+    const currBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+    if (currBranch != deployBranch) {
+        // Abort with an error message
+        console.log(
+            `${format.bold+format.red}ERROR: ` +
+            `${format.reset+format.bold}` +
+            `You must be on the ${deployBranch} branch to deploy.\n${format.reset}` +
+            `Please checkout and pull the latest version of ${deployBranch} before deploying.\n`
+        );
+        console.log(`${format.bold+format.red}Aborting Deploy`);
+        exit(0)
+    }
+        
+    // Create a build for production
+    console.log("Creating a production build...")
+    console.log("> npm run build")
+    execSync('npm run build');
+    console.log(`${format.bold}Build succeeded!\n${format.reset}`)
+
+    // Deploy build to production
+    console.log("Deploying to production...")
+    console.log("> gh-pages -d build")
+    execSync('gh-pages -d build')
+    console.log(`\n${format.bold}🎉 Successfully deployed 🎉${format.reset}`)
+}
+
+deploy()


### PR DESCRIPTION
`npm run deploy` now calls `deploy.js`.
This script does does the exact same thing as before but it's much more organized and outputs updates of it's progress along the way.

Example of successful deploy:
```
ChaseCarnaroli > npm run deploy     

> venushacks@0.1.0 deploy /Users/ChaseCarnaroli/Desktop/Dev/Hack/venushacks
> node scripts/deploy.js

Beginning The Deploy Process!

Creating a production build...
> npm run build
Build succeeded!

Deploying to production...
> gh-pages -d build

🎉 Successfully deployed 🎉
```

Example of a failed deploy from a non-master branch:
```
ChaseCarnaroli > npm run deploy        

> venushacks@0.1.0 deploy /Users/ChaseCarnaroli/Desktop/Dev/Hack/venushacks
> node scripts/deploy.js

Beginning The Deploy Process!

ERROR: You must be on the master branch to deploy.
Please checkout and pull the latest version of master before deploying.

Aborting Deploy
```