### PR TITLE
removed MLH banner and updated VH dates on home page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>VenusHacks 2021</title>
+    <title>VenusHacks 2022</title>
     <link
       rel="stylesheet"
       href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"

--- a/src/app/components/nav/Nav.js
+++ b/src/app/components/nav/Nav.js
@@ -50,11 +50,6 @@ function Nav() {
           </p>
         </Link>
       </div>
-      <div className="nav-right">
-        <a id="mlh-trust-badge" href="https://mlh.io/seasons/2021/events?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2021-season&utm_content=white" target="_blank" rel="noopener noreferrer">
-          <img src="https://s3.amazonaws.com/logged-assets/trust-badge/2021/mlh-trust-badge-2021-white.svg" alt="Major League Hacking 2021 Hackathon Season" />
-        </a>
-      </div>
     </div>
   )
 }

--- a/src/app/views/home/Home.js
+++ b/src/app/views/home/Home.js
@@ -155,7 +155,7 @@ export default class Home extends React.Component {
 
                 <div id="hero-right">
                   <img id="venushacks-title" src={vh_title} alt="VenusHacks Title Logo"/>
-                  <h4 id="date">April 24 - 25, 2021</h4>
+                  <h4 id="date">May 21 - 22, 2022</h4>
                   <p id="tagline">UC Irvine's first women-centric hackathon</p>
                     <Button id="apply-btn">
                       <a href="https://venushacks-2021.devpost.com/" style={{ color: "#99a6e5"}}>


### PR DESCRIPTION
## Summary
Removed MLH banner, updated VH date on home page, and updated page title to "VenusHacks 2022"

## Test Plan
Ran website locally to see if MLH banner was removed and if "April 24 - 25, 2021" changed to "May 21 - 22, 2022," Initially, changing the page title had the "VenusHacks April 24 - 25, 2021" not show up (I do not know why), but after updating the date then updating the page title, it was fine.

## Issue(s)
Closes #119 and #120 

<!-- Optional --->
## Future Followup
Check whether or not we are still MLH affiliated for this year.