### PR TITLE
Hid partners section

### DIFF
--- a/src/app/views/home/Home.scss
+++ b/src/app/views/home/Home.scss
@@ -271,6 +271,7 @@ $laptop: "./../../../assets/images/laptop.png";
   } // END SPONSORS
 
   #partners {
+    display: none;
     margin-top: 50px;
 
     .section-title {


### PR DESCRIPTION
## Summary
I edited the #partners section in Home.scss to include "display: none", which hides the entire section from the Homepage.

## Test Plan
I ran the website locally and saw that the Partners section was no longer being displayed.

## Issue(s)
Closes #128 
