### PR TITLE
Remove www from cname

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-www.venushacks.com
+venushacks.com


### PR DESCRIPTION
## Summary
Remove `www` from venushacks.com

www.venushacks.com still redirects to venushacks.com