### PR TITLE
Fix FAQ Accordion Body Design

### DIFF
--- a/site/src/app/components/faqs/FAQs.scss
+++ b/site/src/app/components/faqs/FAQs.scss
@@ -21,13 +21,23 @@ $arrow: "assets/images/arrow-point-right.svg";
 }
 
 .accordion-body {
-	padding: 25px;
+	padding-bottom: 20px;
+	padding-left: 45px;
+	padding-right: 45px;
+	padding-top: 30px;
 	font-family: Instrument Sans;
 	font-size: 1.25rem;
 	font-weight: 500;
 	background-color: #e0b0d8;
-	border: 4px solid #8659A4;
+	border: 4px solid #8659a4;
 	border-radius: 29px;
+
+	@media screen and (max-width: $break-medium) {
+		padding-bottom: 15px;
+		padding-left: 30px;
+		padding-right: 30px;
+		padding-top: 25px;
+	}
 }
 
 .accordion-item {

--- a/site/src/app/components/faqs/FAQs.scss
+++ b/site/src/app/components/faqs/FAQs.scss
@@ -22,10 +22,12 @@ $arrow: "assets/images/arrow-point-right.svg";
 
 .accordion-body {
 	padding: 25px;
-	font-size: 1.5rem;
-	@media screen and (max-width: $break-medium) {
-		font-size: 1.2rem;
-	}
+	font-family: Instrument Sans;
+	font-size: 1.25rem;
+	font-weight: 500;
+	background-color: #e0b0d8;
+	border: 4px solid #8659A4;
+	border-radius: 29px;
 }
 
 .accordion-item {


### PR DESCRIPTION
I realized I didn't see the full design for the FAQ dropdown on the figma when I first made this section, so some design choices I made for the accordion body were wrong.

- Changed accordion body font family to Instrument Sans and match specified font weight and size
- Changed accordion body background color to light pink
- Added dark purple border and border radius to accordion body