### PR TITLE
change vh-styles.css breakpoints to bootstrap

### DIFF
--- a/site/src/globals/vh-styles.scss
+++ b/site/src/globals/vh-styles.scss
@@ -10,10 +10,10 @@ When graphics gives us their style guidelines we can look here.
 @import url("https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=Londrina+Solid:wght@100;300;400;900&display=swap");
 
 // PX Sizing for Media queries
-$break-small: 500px;
-$break-medium: 900px;
-$break-large: 1250px;
-$break-xlarge: 1600px;
+$break-small: 576px;
+$break-medium: 992px;
+$break-large: 1200px;
+$break-xlarge: 1400px;
 
 // Temporary Appwide Style Variables
 $fontColor: white;


### PR DESCRIPTION
changed vh-styles.css breakpoints to bootstrap standard ones based on the breakpoints [here](https://react-bootstrap.netlify.app/docs/layout/breakpoints/)