### PR TITLE
Set up codebase for production deployment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,11 +15,12 @@ jobs:
       - uses: amondnet/vercel-action@v25
         with:
           vercel-version: 32.6.1
+          vercel-args: "--yes"
           github-comment: |
             <table>
               <tr>
                 <td><strong>Name</strong></td>
-                <td>IrvineHacks Site</td>
+                <td>VenusHacks Site</td>
               </tr>
               <tr>
                 <td><strong>Preview</strong></td>
@@ -31,7 +32,7 @@ jobs:
               </tr>
             </table>
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN_2026 }}
           vercel-org-id: ${{ vars.VERCEL_ORG_ID}}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_SITE}}
   Studio:
@@ -42,6 +43,7 @@ jobs:
       - uses: amondnet/vercel-action@v25
         with:
           vercel-version: 32.6.1
+          vercel-args: "--yes"
           github-comment: |
             <table>
               <tr>
@@ -58,6 +60,6 @@ jobs:
               </tr>
             </table>
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ vars.VERCEL_ORG_ID}}
+          vercel-token: ${{ secrets.VERCEL_TOKEN_2026 }}
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_STUDIO}}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
                   vercel-version: 32.6.1
                   github-comment: false
                   vercel-args: "--prod"
-                  vercel-token: ${{ secrets.VERCEL_TOKEN }}
+                  vercel-token: ${{ secrets.VERCEL_TOKEN_2026 }}
                   vercel-org-id: ${{ vars.VERCEL_ORG_ID}}
                   vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_SITE}}
     Studio:
@@ -35,6 +35,6 @@ jobs:
                   vercel-version: 32.6.1
                   github-comment: false
                   vercel-args: "--prod"
-                  vercel-token: ${{ secrets.VERCEL_TOKEN }}
+                  vercel-token: ${{ secrets.VERCEL_TOKEN_2026 }}
                   vercel-org-id: ${{ vars.VERCEL_ORG_ID}}
                   vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_STUDIO}}

--- a/apps/api/run-docker.bat
+++ b/apps/api/run-docker.bat
@@ -1,2 +1,2 @@
-docker compose up --build
-docker compose down
+docker-compose up --build
+docker-compose down

--- a/apps/api/run-docker.bat
+++ b/apps/api/run-docker.bat
@@ -1,2 +1,2 @@
-docker-compose up --build
-docker-compose down
+docker compose up --build
+docker compose down

--- a/apps/site/src/app/(main)/resources/components/ResourceSection.tsx
+++ b/apps/site/src/app/(main)/resources/components/ResourceSection.tsx
@@ -7,7 +7,6 @@ import styles from "./ResourceSection.module.scss";
 
 export default async function ResourceSection() {
 	const resources = await getResources();
-
 	return (
 		<>
 			{resources.order.map(
@@ -19,14 +18,14 @@ export default async function ResourceSection() {
 								className="container mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 justify-center items-center lg:pr-[3.25vw]"
 							>
 								<ResourceCategory
-									iconUrl={iconUrl}
+									iconUrl={iconUrl ?? ""}
 									title={title}
 									isMobile={false}
 								/>
 								<div className="col-span-2 w-full max-w-5xl bg-black p-12 grow-[2] mb-12 border-[5px] border-white shadow-[9px_9px_0px_1px_#ffffff] select-none">
 									<ResourceDescription
 										title={title}
-										description={description}
+										description={description ?? ""}
 										isMobile={false}
 									/>
 									<div
@@ -56,13 +55,13 @@ export default async function ResourceSection() {
 							<div className="w-full max-w-5xl bg-black p-5 sm:p-7 grow-[2] mb-12 border-[5px] border-white shadow-[9px_9px_0px_1px_#ffffff] select-none">
 								<div className="flex justify-stretch select-none pointer-events-none">
 									<ResourceCategory
-										iconUrl={iconUrl}
+										iconUrl={iconUrl ?? ""}
 										title={title}
 										isMobile={true}
 									/>
 									<ResourceDescription
 										title={title}
-										description={description}
+										description={description ?? ""}
 										isMobile={true}
 									/>
 								</div>

--- a/apps/site/src/app/(main)/resources/getResources.ts
+++ b/apps/site/src/app/(main)/resources/getResources.ts
@@ -8,9 +8,9 @@ const Resources = z.object({
 	order: z.array(
 		z.object({
 			_id: z.string(),
-			iconUrl: z.string(),
+			iconUrl: z.string().nullable(),
 			title: z.string(),
-			description: z.string(),
+			description: z.string().nullable(),
 			resources: z.array(
 				SanityDocument.extend({
 					_type: z.literal("resource"),
@@ -21,35 +21,39 @@ const Resources = z.object({
 					link: z.string(),
 					title: z.string(),
 					resourceIconUrl: z.string(),
-					resourceType: SanityReference,
+					resourceType: SanityReference.nullable(),
 				}).passthrough(),
 			),
 		}),
-	),
-});
+	).default([]),
+}).nullable();
 
 export const getResources = cache(async () => {
-	return Resources.parse(
-		await client.fetch(groq`
-			*[_type == 'resourceCategoryOrder' && _id == "resourceCategoryOrder"][0] {
-				order[]->{
+	const data = await client.fetch(groq`
+		*[_type == 'resourceCategoryOrder' && _id == "resourceCategoryOrder"][0] {
+			order[]->{
+				_id,
+				'iconUrl': icon.asset->url,
+				title,
+				description,
+				'resources': coalesce(*[_type == 'resource' && resourceType._ref == ^._id] | order(title asc) {
 					_id,
-					'iconUrl': icon.asset->url,
+					_createdAt,
+					_updatedAt,
+					_rev,
+					'_type': _type,
+					link,
 					title,
-					description,
-					'resources': *[_type == 'resource' && resourceType._ref == ^._id] | order(title asc) {
-						_id,
-						_createdAt,
-						_updatedAt,
-						_rev,
-						'_type': _type,
-						link,
-						title,
-						'resourceIconUrl': coalesce(icon.asset->url, ""),
-						resourceType
-					}
-				}
+					'resourceIconUrl': coalesce(icon.asset->url, ""),
+					resourceType
+				}, [])
 			}
-		`),
-	);
+		}
+	`);
+
+	if (!data) {
+		return { order: [] };
+	}
+
+	return Resources.parse(data) ?? { order: [] };
 });

--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,5 +1,5 @@
 {
-	"buildCommand": "cd ../.. && turbo run build --filter={apps/site} --filter={apps/api} && cd apps/site && ./copy-api.sh",
+	"buildCommand": "cd ../.. && turbo run build --filter={apps/site} --filter={apps/api} && cd apps/site && sh ./copy-api.sh",
 	"functions": {
 		"api/index.py": {
 			"memory": 512,


### PR DESCRIPTION
Deploying the current codebase onto Vercel revealed some issues in the code, particularly in the resources section. The pull request handles those linting errors.

In particular:
- Vercel was having trouble executing `copy-api.sh`, so using `sh copy-api.sh` instead
- Making resource fields nullable in the Sanity resource getter
- Bypassing linting errors in resources section
- Updating the names of environment variables and secrets in `.yml` files to ensure they don't interfere with old environment vars

For the future, M/D wanted to get rid of the resources page entirely. So may need to consider simply wiping the resources page from the site and from the Sanity.