### PR TITLE
Remove second reviewer from reviewing portal

### DIFF
--- a/apps/api/src/admin/applicant_review_processor.py
+++ b/apps/api/src/admin/applicant_review_processor.py
@@ -84,7 +84,8 @@ def _get_avg_score(
 # ) -> float:
 #     # Check global_field_scores first - if any value is less than 0,
 #     # return OVERQUALIFIED
-#     if global_field_scores and any(score < 0 for score in global_field_scores.values()):
+#     if global_field_scores
+#             and any(score < 0 for score in global_field_scores.values()):
 #         return OVERQUALIFIED
 
 #     if len(review_breakdowns) < 2:
@@ -103,11 +104,12 @@ def _get_avg_score(
 
 #     return (total_score / 2) / MAX_SCORE * 100
 
+
 # For the purposes of VenusHacks 2026, we'll only consider the review that was submitted
 # last. For instance, If three reviewers each submitted their own review of a hacker
 # application, only the most recent one will be considered in the "average value".
 #
-# To revert this back to the average of all the reviews, remove the definition for  
+# To revert this back to the average of all the reviews, remove the definition for
 # _get_avg_score_with_globals_and_breakdown below and uncomment the old definition
 # above. Then, update expected_records.avg_score with the corrected average in
 # test_admin.py::test_hacker_applicants_returns_correct_applicants()

--- a/apps/api/src/admin/applicant_review_processor.py
+++ b/apps/api/src/admin/applicant_review_processor.py
@@ -79,29 +79,56 @@ def _get_avg_score(
     return (last_score + last_score2) / 2
 
 
+# def _get_avg_score_with_globals_and_breakdown(
+#     review_breakdowns: dict[str, dict[str, int]], global_field_scores: dict[str, int]
+# ) -> float:
+#     # Check global_field_scores first - if any value is less than 0,
+#     # return OVERQUALIFIED
+#     if global_field_scores and any(score < 0 for score in global_field_scores.values()):
+#         return OVERQUALIFIED
+
+#     if len(review_breakdowns) < 2:
+#         return NOT_FULLY_REVIEWED
+
+#     # Review breakdowns should be the most recent scores
+#     total_score = 2 * sum(global_field_scores.values())
+#     for breakdown in review_breakdowns.values():
+#         for field, score in breakdown.items():
+#             # TODO: Fields from global_field_scores should not be in breakdowns
+#             # This check should be removed once breakdown models remove global fields
+#             if field in global_field_scores:
+#                 continue
+
+#             total_score += score
+
+#     return (total_score / 2) / MAX_SCORE * 100
+
+# For the purposes of VenusHacks 2026, we'll only consider the review that was submitted
+# last. For instance, If three reviewers each submitted their own review of a hacker
+# application, only the most recent one will be considered in the "average value".
+#
+# To revert this back to the average of all the reviews, remove the definition for  
+# _get_avg_score_with_globals_and_breakdown below and uncomment the old definition
+# above. Then, update expected_records.avg_score with the corrected average in
+# test_admin.py::test_hacker_applicants_returns_correct_applicants()
 def _get_avg_score_with_globals_and_breakdown(
     review_breakdowns: dict[str, dict[str, int]], global_field_scores: dict[str, int]
 ) -> float:
-    # Check global_field_scores first - if any value is less than 0,
-    # return OVERQUALIFIED
     if global_field_scores and any(score < 0 for score in global_field_scores.values()):
         return OVERQUALIFIED
 
     if len(review_breakdowns) < 2:
         return NOT_FULLY_REVIEWED
 
-    # Review breakdowns should be the most recent scores
-    total_score = 2 * sum(global_field_scores.values())
-    for breakdown in review_breakdowns.values():
-        for field, score in breakdown.items():
-            # TODO: Fields from global_field_scores should not be in breakdowns
-            # This check should be removed once breakdown models remove global fields
-            if field in global_field_scores:
-                continue
+    last_breakdown = list(review_breakdowns.values())[-1]
 
-            total_score += score
+    total_score = sum(global_field_scores.values())
+    for field, score in last_breakdown.items():
+        if field in global_field_scores:
+            continue
+        total_score += score
 
-    return (total_score / 2) / MAX_SCORE * 100
+    return total_score / MAX_SCORE * 100
 
 
 def _include_decision_based_on_threshold(

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -386,7 +386,7 @@ def test_hacker_applicants_returns_correct_applicants(
             "resume_reviewed": True,
             "status": "REVIEWED",
             "decision": "ACCEPTED",  # 56.67 >= accept threshold 50
-            "avg_score": 56.666666666666664,
+            "avg_score": 60,
             "reviewers": ["edu.uci.alicia", "edu.uci.alicia2"],
             "application_data": {
                 "school": "Hamburger University",

--- a/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
@@ -48,22 +48,21 @@ const statusOption = (status: Status): MultiselectProps.Option => ({
 	iconName: StatusIcons[status],
 });
 
-const RESUME_REVIEW_OPTIONS: Options = [
-	{
-		label: "Resume Reviewed",
-		value: "RESUME_REVIEWED",
-		iconName: "status-positive",
-	},
-	{
-		label: "Resume Not Reviewed",
-		value: "RESUME_NOT_REVIEWED",
-		iconName: "status-pending",
-	},
-];
+// const RESUME_REVIEW_OPTIONS: Options = [
+// 	{
+// 		label: "Resume Reviewed",
+// 		value: "RESUME_REVIEWED",
+// 		iconName: "status-positive",
+// 	},
+// 	{
+// 		label: "Resume Not Reviewed",
+// 		value: "RESUME_NOT_REVIEWED",
+// 		iconName: "status-pending",
+// 	},
+// ];
 
-const STATUS_OPTIONS = Object.values(ReviewStatus)
-	.map(statusOption)
-	// .concat(RESUME_REVIEW_OPTIONS);
+const STATUS_OPTIONS = Object.values(ReviewStatus).map(statusOption)
+// .concat(RESUME_REVIEW_OPTIONS);
 
 const DECISION_OPTIONS = Object.values(Decision).map(statusOption);
 

--- a/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
@@ -63,7 +63,7 @@ const RESUME_REVIEW_OPTIONS: Options = [
 
 const STATUS_OPTIONS = Object.values(ReviewStatus)
 	.map(statusOption)
-	.concat(RESUME_REVIEW_OPTIONS);
+	// .concat(RESUME_REVIEW_OPTIONS);
 
 const DECISION_OPTIONS = Object.values(Decision).map(statusOption);
 

--- a/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
@@ -61,7 +61,7 @@ const statusOption = (status: Status): MultiselectProps.Option => ({
 // 	},
 // ];
 
-const STATUS_OPTIONS = Object.values(ReviewStatus).map(statusOption)
+const STATUS_OPTIONS = Object.values(ReviewStatus).map(statusOption);
 // .concat(RESUME_REVIEW_OPTIONS);
 
 const DECISION_OPTIONS = Object.values(Decision).map(statusOption);

--- a/apps/site/src/app/admin/applicants/components/ApplicantReviewerIndicator.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantReviewerIndicator.tsx
@@ -4,18 +4,16 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 
 interface IndicatorContainerProps {
-	displayNumber: number;
-	reviewer: string | undefined;
+	reviewer: string;
 }
 
 const IndicatorContainer = ({
-	displayNumber,
 	reviewer,
 }: IndicatorContainerProps) => {
 	return (
 		<>
 			<Box variant="awsui-key-label">
-				Reviewer {displayNumber}: {reviewer}
+				Reviewer: {reviewer}
 			</Box>
 			{reviewer ? (
 				<StatusIndicator>Reviewed</StatusIndicator>
@@ -33,17 +31,13 @@ interface ApplicantReviewerIndicatorProps {
 function ApplicantReviewerIndicator({
 	reviewers,
 }: ApplicantReviewerIndicatorProps) {
-	const formatUid = (uid: Uid) => uid.split(".").at(-1);
+	const formatUid = (uid: string | undefined) => uid?.split(".").at(-1) ?? "";
 
 	return (
 		<SpaceBetween size="l">
-			{[0, 1].map((n) => (
-				<IndicatorContainer
-					key={n}
-					displayNumber={n + 1}
-					reviewer={reviewers[n] ? formatUid(reviewers[n]) : ""}
-				/>
-			))}
+			<IndicatorContainer
+				reviewer={formatUid(reviewers.at(-1))}
+			/>
 		</SpaceBetween>
 	);
 }

--- a/apps/site/src/app/admin/applicants/components/ApplicantReviewerIndicator.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantReviewerIndicator.tsx
@@ -1,4 +1,3 @@
-import { Uid } from "@/lib/userRecord";
 import Box from "@cloudscape-design/components/box";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
@@ -7,14 +6,10 @@ interface IndicatorContainerProps {
 	reviewer: string;
 }
 
-const IndicatorContainer = ({
-	reviewer,
-}: IndicatorContainerProps) => {
+const IndicatorContainer = ({ reviewer }: IndicatorContainerProps) => {
 	return (
 		<>
-			<Box variant="awsui-key-label">
-				Reviewer: {reviewer}
-			</Box>
+			<Box variant="awsui-key-label">Reviewer: {reviewer}</Box>
 			{reviewer ? (
 				<StatusIndicator>Reviewed</StatusIndicator>
 			) : (
@@ -35,9 +30,7 @@ function ApplicantReviewerIndicator({
 
 	return (
 		<SpaceBetween size="l">
-			<IndicatorContainer
-				reviewer={formatUid(reviewers.at(-1))}
-			/>
+			<IndicatorContainer reviewer={formatUid(reviewers.at(-1))} />
 		</SpaceBetween>
 	);
 }

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
@@ -217,7 +217,7 @@ function HackerApplicantsList() {
 						},
 						{
 							id: "avg_score",
-							header: "Averaged Score",
+							header: "Applicant Score",
 							content: avgScore,
 						},
 						{

--- a/apps/site/src/app/admin/applicants/components/ReviewerNotes.tsx
+++ b/apps/site/src/app/admin/applicants/components/ReviewerNotes.tsx
@@ -36,7 +36,7 @@ export default function ReviewerNotes({
 					const reviewer = review[1];
 					const note = review[3];
 					return (
-						<li key={originalIdx} style={{ marginBottom: "0.5rem" }}>
+						<li key={originalIdx} style={{ marginBottom: "0.5rem", listStyle: "none" }}>
 							<div
 								style={{
 									display: "flex",

--- a/apps/site/src/app/admin/applicants/components/ReviewerNotes.tsx
+++ b/apps/site/src/app/admin/applicants/components/ReviewerNotes.tsx
@@ -36,7 +36,10 @@ export default function ReviewerNotes({
 					const reviewer = review[1];
 					const note = review[3];
 					return (
-						<li key={originalIdx} style={{ marginBottom: "0.5rem", listStyle: "none" }}>
+						<li
+							key={originalIdx}
+							style={{ marginBottom: "0.5rem", listStyle: "none" }}
+						>
 							<div
 								style={{
 									display: "flex",


### PR DESCRIPTION
## Changes
- Temporarily change API route `GET /api/admin/applicants/hackers` to return score of last reviewer rather than the average.
- Updated API test accordingly
- Updated hacker reviewing portal accordingly