### PR TITLE
Minor fix to email confirmation waiver

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,3 +8,4 @@ pydantic[email]==2.10.3
 aiosendgrid==0.1.0
 sendgrid==6.11.0
 aiogoogle==5.6.0
+markdown==3.7

--- a/apps/api/src/routers/waiver.py
+++ b/apps/api/src/routers/waiver.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from typing import Annotated
 import hashlib
 import re
+import markdown
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, field_validator
@@ -148,7 +149,7 @@ async def submit_waiver(
             last_name=user_record["last_name"],
             full_signature=body.full_signature,
             timestamp=timestamp,
-            waiver_text=canonical_waiver_text,
+            waiver_text=markdown.markdown(canonical_waiver_text),
         )
     except RuntimeError:
         log.error("Could not send waiver confirmation email to %s", user.uid)

--- a/apps/api/tests/test_waiver.py
+++ b/apps/api/tests/test_waiver.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY, AsyncMock, patch
 
 from fastapi import FastAPI
+import markdown
 
 from auth import user_identity
 from auth.user_identity import NativeUser, UserTestClient
@@ -93,7 +94,7 @@ def test_submit_waiver_success(
         last_name="User",
         full_signature="Apply User",
         timestamp=ANY,
-        waiver_text=WAIVER_DOCUMENT["text"],
+        waiver_text=markdown.markdown(WAIVER_DOCUMENT["text"]),
     )
 
 


### PR DESCRIPTION
Added a minor change to the waiver confirmation email template: rather than passing in the raw markdown text, we first convert it to html using `markdown` in Python.